### PR TITLE
[BudgetManager] Add family data loader, API test project, and GraphQL

### DIFF
--- a/Sandbox/BudgetManager/CLAUDE.md
+++ b/Sandbox/BudgetManager/CLAUDE.md
@@ -105,6 +105,7 @@ docker-compose up -d   # start PostgreSQL
 
 - **No `Async` suffix** — do not add `Async` to async method names.
 - **Model-first GraphQL** — for each aggregate exposed via GraphQL, define an `ObjectType<T>` (e.g. `CategoryObjectType : ObjectType<Category>`) in `BudgetManager.Api/GraphQL/{Feature}/` and register it with `.AddType<>()` before adding queries or mutations that return the aggregate.
+- **FluentAssertions in tests** — use FluentAssertions (`.Should().Be(...)`, `.Should().NotBeEmpty()`, etc.) instead of `Assert.*` in all test projects.
 
 ## CQRS Conventions
 

--- a/Sandbox/BudgetManager/backend/BudgetManager.slnx
+++ b/Sandbox/BudgetManager/backend/BudgetManager.slnx
@@ -6,6 +6,7 @@
     <Project Path="src/BudgetManager.Infrastructure/BudgetManager.Infrastructure.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/BudgetManager.Api.Tests/BudgetManager.Api.Tests.csproj" />
     <Project Path="tests/BudgetManager.Application.Tests/BudgetManager.Application.Tests.csproj" />
     <Project Path="tests/BudgetManager.Domain.Tests/BudgetManager.Domain.Tests.csproj" />
     <Project Path="tests/BudgetManager.Infrastructure.Tests/BudgetManager.Infrastructure.Tests.csproj" />

--- a/Sandbox/BudgetManager/backend/Directory.Packages.props
+++ b/Sandbox/BudgetManager/backend/Directory.Packages.props
@@ -43,9 +43,14 @@
 
   <!-- Testing -->
   <ItemGroup>
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/Sandbox/BudgetManager/backend/src/BudgetManager.Api/GraphQL/Categories/CategoryObjectType.cs
+++ b/Sandbox/BudgetManager/backend/src/BudgetManager.Api/GraphQL/Categories/CategoryObjectType.cs
@@ -1,3 +1,4 @@
+using BudgetManager.Api.GraphQL.Families;
 using BudgetManager.Domain.Categories;
 using HotChocolate.Types;
 
@@ -23,5 +24,11 @@ public class CategoryObjectType : ObjectType<Category>
         descriptor.Field(c => c.FamilyId)
             .Type<NonNullType<UuidType>>()
             .Resolve(ctx => ctx.Parent<Category>().FamilyId.Value);
+
+        descriptor.Field("family")
+            .Type<NonNullType<FamilyObjectType>>()
+            .Resolve(ctx =>
+                ctx.DataLoader<FamilyByIdDataLoader>()
+                    .LoadAsync(ctx.Parent<Category>().FamilyId.Value, ctx.RequestAborted));
     }
 }

--- a/Sandbox/BudgetManager/backend/src/BudgetManager.Api/GraphQL/DependencyInjection.cs
+++ b/Sandbox/BudgetManager/backend/src/BudgetManager.Api/GraphQL/DependencyInjection.cs
@@ -13,7 +13,8 @@ public static class DependencyInjection
             .AddQueryType<Query>()
             .AddMutationType<Mutation>()
             .AddType<CategoryObjectType>()
-            .AddType<FamilyObjectType>();
+            .AddType<FamilyObjectType>()
+            .AddDataLoader<FamilyByIdDataLoader>();
 
         return services;
     }

--- a/Sandbox/BudgetManager/backend/src/BudgetManager.Api/GraphQL/Families/FamilyByIdDataLoader.cs
+++ b/Sandbox/BudgetManager/backend/src/BudgetManager.Api/GraphQL/Families/FamilyByIdDataLoader.cs
@@ -1,0 +1,26 @@
+using BudgetManager.Application.Families;
+using BudgetManager.Domain.Families;
+using GreenDonut;
+using MediatR;
+
+namespace BudgetManager.Api.GraphQL.Families;
+
+public sealed class FamilyByIdDataLoader(
+    IMediator mediator,
+    IBatchScheduler batchScheduler,
+    DataLoaderOptions options)
+    : BatchDataLoader<Guid, Family>(batchScheduler, options)
+{
+    protected override async Task<IReadOnlyDictionary<Guid, Family>> LoadBatchAsync(
+        IReadOnlyList<Guid> keys,
+        CancellationToken cancellationToken)
+    {
+        var familyIds = keys.Select(k => new FamilyId(k)).ToList();
+
+        var families = await mediator.Send(
+            new GetFamiliesByIdsQuery(familyIds),
+            cancellationToken);
+
+        return families.ToDictionary(f => f.Id.Value);
+    }
+}

--- a/Sandbox/BudgetManager/backend/src/BudgetManager.Api/GraphQL/Query.cs
+++ b/Sandbox/BudgetManager/backend/src/BudgetManager.Api/GraphQL/Query.cs
@@ -10,8 +10,6 @@ namespace BudgetManager.Api.GraphQL;
 
 public class Query
 {
-    public string Ping() => "pong";
-
     [GraphQLType(typeof(ListType<CategoryObjectType>))]
     public Task<IReadOnlyList<Category>> IncomeCategories(
         Guid familyId,

--- a/Sandbox/BudgetManager/backend/src/BudgetManager.Api/Program.cs
+++ b/Sandbox/BudgetManager/backend/src/BudgetManager.Api/Program.cs
@@ -29,3 +29,6 @@ static async Task InitializeDatabaseAsync(IHost app)
         .GetRequiredService<BudgetManagerDbContextInitializer>()
         .InitialiseAsync();
 }
+
+public partial class Program;
+

--- a/Sandbox/BudgetManager/backend/src/BudgetManager.Application/Families/GetFamiliesByIdsQuery.cs
+++ b/Sandbox/BudgetManager/backend/src/BudgetManager.Application/Families/GetFamiliesByIdsQuery.cs
@@ -1,0 +1,20 @@
+using BudgetManager.Application.Common.Interfaces;
+using BudgetManager.Application.Common.MediatR;
+using BudgetManager.Domain.Families;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace BudgetManager.Application.Families;
+
+public record GetFamiliesByIdsQuery(IReadOnlyCollection<FamilyId> Ids)
+    : IQuery<IReadOnlyList<Family>>;
+
+internal sealed class GetFamiliesByIdsQueryHandler(IBudgetManagerDbContext db)
+    : IRequestHandler<GetFamiliesByIdsQuery, IReadOnlyList<Family>>
+{
+    public async Task<IReadOnlyList<Family>> Handle(
+        GetFamiliesByIdsQuery request, CancellationToken cancellationToken)
+        => await db.Families
+            .Where(f => request.Ids.Contains(f.Id))
+            .ToListAsync(cancellationToken);
+}

--- a/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/BudgetManager.Api.Tests.csproj
+++ b/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/BudgetManager.Api.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="HotChocolate.AspNetCore" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BudgetManager.Api\BudgetManager.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/Categories/AddCategoryTests.cs
+++ b/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/Categories/AddCategoryTests.cs
@@ -1,0 +1,155 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AutoFixture;
+using FluentAssertions;
+using Testcontainers.PostgreSql;
+
+namespace BudgetManager.Api.Tests.Categories;
+
+public class AddCategoryTests : IAsyncLifetime
+{
+    private readonly IFixture _fixture = new Fixture()
+        .Customize(new DbSetup())
+        .Customize(new TestServerSetup());
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.Create<PostgreSqlContainer>().DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AddIncomeCategory_ReturnsCategory()
+    {
+        var client = _fixture.Create<HttpClient>();
+        var familyId = await RegisterFamilyAsync(client);
+
+        var response = await client.PostAsJsonAsync("/graphql", new
+        {
+            query = """
+                mutation($familyId: UUID!) {
+                  addIncomeCategory(name: "Salary", iconUrl: "salary.png", familyId: $familyId) {
+                    id
+                    name
+                    type
+                    familyId
+                  }
+                }
+                """,
+            variables = new { familyId }
+        });
+
+        response.EnsureSuccessStatusCode();
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var category = doc.RootElement.GetProperty("data").GetProperty("addIncomeCategory");
+
+        Guid.Parse(category.GetProperty("id").GetString()!).Should().NotBeEmpty();
+        category.GetProperty("name").GetString().Should().Be("Salary");
+        category.GetProperty("type").GetString().Should().Be("INCOME");
+        category.GetProperty("familyId").GetString().Should().Be(familyId);
+    }
+
+    [Fact]
+    public async Task AddExpenseCategory_ReturnsCategory()
+    {
+        var client = _fixture.Create<HttpClient>();
+        var familyId = await RegisterFamilyAsync(client);
+
+        var response = await client.PostAsJsonAsync("/graphql", new
+        {
+            query = """
+                mutation($familyId: UUID!) {
+                  addExpenseCategory(name: "Groceries", iconUrl: "groceries.png", familyId: $familyId) {
+                    id
+                    name
+                    type
+                    familyId
+                  }
+                }
+                """,
+            variables = new { familyId }
+        });
+
+        response.EnsureSuccessStatusCode();
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var category = doc.RootElement.GetProperty("data").GetProperty("addExpenseCategory");
+
+        Guid.Parse(category.GetProperty("id").GetString()!).Should().NotBeEmpty();
+        category.GetProperty("name").GetString().Should().Be("Groceries");
+        category.GetProperty("type").GetString().Should().Be("EXPENSE");
+        category.GetProperty("familyId").GetString().Should().Be(familyId);
+    }
+
+    [Fact]
+    public async Task IncomeCategories_LoadsFamily()
+    {
+        var client = _fixture.Create<HttpClient>();
+        var familyId = await RegisterFamilyAsync(client);
+
+        await client.PostAsJsonAsync("/graphql", new
+        {
+            query = """
+                mutation($familyId: UUID!) {
+                  addIncomeCategory(name: "Salary", iconUrl: "salary.png", familyId: $familyId) {
+                    id
+                  }
+                }
+                """,
+            variables = new { familyId }
+        });
+
+        var response = await client.PostAsJsonAsync("/graphql", new
+        {
+            query = """
+                query($familyId: UUID!) {
+                  incomeCategories(familyId: $familyId) {
+                    name
+                    family {
+                      id
+                      name
+                    }
+                  }
+                }
+                """,
+            variables = new { familyId }
+        });
+
+        response.EnsureSuccessStatusCode();
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var category = doc.RootElement
+            .GetProperty("data")
+            .GetProperty("incomeCategories")[0];
+
+        category.GetProperty("name").GetString().Should().Be("Salary");
+
+        var family = category.GetProperty("family");
+        family.GetProperty("id").GetString().Should().Be(familyId);
+        family.GetProperty("name").GetString().Should().Be("TestFamily");
+    }
+
+    private static async Task<string> RegisterFamilyAsync(HttpClient client)
+    {
+        var response = await client.PostAsJsonAsync("/graphql", new
+        {
+            query = """
+                mutation {
+                  registerFamily(name: "TestFamily") {
+                    id
+                  }
+                }
+                """
+        });
+        response.EnsureSuccessStatusCode();
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement
+            .GetProperty("data")
+            .GetProperty("registerFamily")
+            .GetProperty("id")
+            .GetString()!;
+    }
+}

--- a/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/CustomWebApplicationFactory.cs
+++ b/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/CustomWebApplicationFactory.cs
@@ -1,0 +1,22 @@
+using AutoFixture;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Testcontainers.PostgreSql;
+
+namespace BudgetManager.Api.Tests;
+
+public class CustomWebApplicationFactory<TProgram>(IFixture fixture)
+    : WebApplicationFactory<TProgram> where TProgram : class
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        var connectionString = fixture.Create<PostgreSqlContainer>().GetConnectionString();
+
+        builder.ConfigureAppConfiguration((_, config) =>
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = connectionString
+            }));
+    }
+}

--- a/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/DbSetup.cs
+++ b/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/DbSetup.cs
@@ -1,0 +1,45 @@
+using AutoFixture;
+using BudgetManager.Application;
+using BudgetManager.Infrastructure;
+using BudgetManager.Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Testcontainers.PostgreSql;
+
+namespace BudgetManager.Api.Tests;
+
+public class DbSetup : ICustomization
+{
+    public void Customize(IFixture fixture)
+    {
+        var container = new PostgreSqlBuilder("postgres:17-alpine")
+            .WithDatabase("budgetmanager")
+            .WithUsername("budgetmanager")
+            .WithPassword("budgetmanager")
+            .Build();
+
+        container.StartAsync().GetAwaiter().GetResult();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = container.GetConnectionString()
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddApplication();
+        services.AddInfrastructure(configuration);
+
+        var sp = services.BuildServiceProvider();
+
+        using var scope = sp.CreateScope();
+        scope.ServiceProvider
+            .GetRequiredService<BudgetManagerDbContextInitializer>()
+            .InitialiseAsync().GetAwaiter().GetResult();
+
+        fixture.Inject(container);
+        fixture.Inject(sp.GetRequiredService<IServiceScopeFactory>());
+    }
+}

--- a/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/Families/RegisterFamilyTests.cs
+++ b/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/Families/RegisterFamilyTests.cs
@@ -1,0 +1,49 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using AutoFixture;
+using FluentAssertions;
+using Testcontainers.PostgreSql;
+
+namespace BudgetManager.Api.Tests.Families;
+
+public class RegisterFamilyTests : IAsyncLifetime
+{
+    private readonly IFixture _fixture = new Fixture()
+        .Customize(new DbSetup())
+        .Customize(new TestServerSetup());
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.Create<PostgreSqlContainer>().DisposeAsync();
+    }
+
+    [Fact]
+    public async Task RegisterFamily_PersistsFamily()
+    {
+        var client = _fixture.Create<HttpClient>();
+
+        var response = await client.PostAsJsonAsync("/graphql", new
+        {
+            query = """
+                mutation {
+                  registerFamily(name: "Smith") {
+                    id
+                    name
+                  }
+                }
+                """
+        });
+
+        response.EnsureSuccessStatusCode();
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var family = doc.RootElement
+            .GetProperty("data")
+            .GetProperty("registerFamily");
+
+        family.GetProperty("name").GetString().Should().Be("Smith");
+        Guid.Parse(family.GetProperty("id").GetString()!).Should().NotBeEmpty();
+    }
+}

--- a/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/SchemaSnapshotTests.cs
+++ b/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/SchemaSnapshotTests.cs
@@ -1,0 +1,44 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using BudgetManager.Api.GraphQL;
+using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using IOPath = System.IO.Path;
+
+namespace BudgetManager.Api.Tests;
+
+public class SchemaSnapshotTests
+{
+    [Fact]
+    public async Task Schema_MatchesSnapshot()
+    {
+        var services = new ServiceCollection();
+        services.AddGraphQl();
+
+        var sp = services.BuildServiceProvider();
+        var executor = await sp
+            .GetRequiredService<IRequestExecutorResolver>()
+            .GetRequestExecutorAsync();
+
+        var actualSchema = executor.Schema.ToString();
+
+        var snapshotPath = GetSnapshotPath();
+
+        if (!File.Exists(snapshotPath) ||
+            Environment.GetEnvironmentVariable("UPDATE_SCHEMA_SNAPSHOT") == "true")
+        {
+            Directory.CreateDirectory(IOPath.GetDirectoryName(snapshotPath)!);
+            await File.WriteAllTextAsync(snapshotPath, actualSchema, Encoding.UTF8);
+            return;
+        }
+
+        var expectedSchema = await File.ReadAllTextAsync(snapshotPath);
+        Assert.Equal(expectedSchema, actualSchema);
+    }
+
+    private static string GetSnapshotPath([CallerFilePath] string sourceFile = "")
+        => IOPath.Combine(
+            IOPath.GetDirectoryName(sourceFile)!,
+            "__snapshots__",
+            "schema.graphql");
+}

--- a/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/TestServerSetup.cs
+++ b/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/TestServerSetup.cs
@@ -1,0 +1,12 @@
+using AutoFixture;
+
+namespace BudgetManager.Api.Tests;
+
+public class TestServerSetup : ICustomization
+{
+    public void Customize(IFixture fixture)
+    {
+        var client = new CustomWebApplicationFactory<Program>(fixture).CreateClient();
+        fixture.Inject(client);
+    }
+}

--- a/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/__snapshots__/schema.graphql
+++ b/Sandbox/BudgetManager/backend/tests/BudgetManager.Api.Tests/__snapshots__/schema.graphql
@@ -1,0 +1,44 @@
+﻿schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Category {
+  id: UUID! @cost(weight: "10")
+  name: String!
+  iconUrl: String!
+  type: CategoryType!
+  familyId: UUID! @cost(weight: "10")
+  family: Family! @cost(weight: "10")
+}
+
+type Family {
+  id: UUID! @cost(weight: "10")
+  name: String!
+  iconUrl: String
+}
+
+type Mutation {
+  addIncomeCategory(name: String! iconUrl: String! familyId: UUID!): Category @cost(weight: "10")
+  addExpenseCategory(name: String! iconUrl: String! familyId: UUID!): Category @cost(weight: "10")
+  registerFamily(name: String! iconUrl: String): Family @cost(weight: "10")
+}
+
+type Query {
+  incomeCategories(familyId: UUID!): [Category] @cost(weight: "10")
+  expenseCategories(familyId: UUID!): [Category] @cost(weight: "10")
+  families: [Family] @cost(weight: "10")
+}
+
+enum CategoryType {
+  INCOME
+  EXPENSE
+}
+
+"The purpose of the `cost` directive is to define a `weight` for GraphQL types, fields, and arguments. Static analysis can use these weights when calculating the overall cost of a query or response."
+directive @cost("The `weight` argument defines what value to add to the overall cost for every appearance, or possible appearance, of a type, field, argument, etc." weight: String!) on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM | INPUT_FIELD_DEFINITION
+
+"The `@specifiedBy` directive is used within the type system definition language to provide a URL for specifying the behavior of custom scalar definitions."
+directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
+
+scalar UUID @specifiedBy(url: "https:\/\/tools.ietf.org\/html\/rfc4122")


### PR DESCRIPTION
- Add FamilyByIdDataLoader (BatchDataLoader) and GetFamiliesByIdsQuery to batch-fetch families and avoid N+1 queries
- Extend CategoryObjectType with a family field resolved via the data loader
- Add BudgetManager.Api.Tests project with DbSetup and TestServerSetup AutoFixture customizations (Testcontainers + WebApplicationFactory)
- Add schema snapshot test to track GraphQL SDL changes
- Add integration tests for registerFamily, addIncomeCategory, addExpenseCategory mutations
- Add test verifying the data loader resolves family from incomeCategories query
- Remove unused ping query; add FluentAssertions rule to CLAUDE.md